### PR TITLE
Add in-memory CRUD for business catalogs

### DIFF
--- a/Controllers/MarcaController.cs
+++ b/Controllers/MarcaController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+using Farmacheck.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Farmacheck.Controllers
+{
+    public class MarcaController : Controller
+    {
+        private static readonly List<Marca> _marcas = new();
+        private static int _nextId = 1;
+
+        public IActionResult Index(int unidadId)
+        {
+            ViewBag.UnidadId = unidadId;
+            var lista = _marcas.Where(m => m.UnidadDeNegocioId == unidadId).ToList();
+            return View(lista);
+        }
+
+        [HttpGet]
+        public JsonResult Listar(int unidadId)
+        {
+            var lista = _marcas.Where(m => m.UnidadDeNegocioId == unidadId).ToList();
+            return Json(new { success = true, data = lista });
+        }
+
+        [HttpGet]
+        public JsonResult Obtener(int id)
+        {
+            var entidad = _marcas.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            return Json(new { success = true, data = entidad });
+        }
+
+        [HttpPost]
+        public JsonResult Guardar([FromBody] Marca model)
+        {
+            if (string.IsNullOrWhiteSpace(model.Nombre))
+                return Json(new { success = false, error = "El nombre es obligatorio." });
+
+            if (model.Id == 0)
+            {
+                model.Id = _nextId++;
+                _marcas.Add(model);
+            }
+            else
+            {
+                var existente = _marcas.FirstOrDefault(x => x.Id == model.Id);
+                if (existente == null)
+                    return Json(new { success = false, error = "No encontrado" });
+
+                existente.Nombre = model.Nombre;
+                existente.Logotipo = model.Logotipo;
+                existente.UnidadDeNegocioId = model.UnidadDeNegocioId;
+            }
+
+            return Json(new { success = true, id = model.Id });
+        }
+
+        [HttpPost]
+        public JsonResult Eliminar(int id)
+        {
+            var entidad = _marcas.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            _marcas.Remove(entidad);
+            return Json(new { success = true });
+        }
+    }
+}

--- a/Controllers/SubMarcaController.cs
+++ b/Controllers/SubMarcaController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Farmacheck.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Farmacheck.Controllers
+{
+    public class SubMarcaController : Controller
+    {
+        private static readonly List<SubMarca> _submarcas = new();
+        private static int _nextId = 1;
+
+        public IActionResult Index(int marcaId)
+        {
+            ViewBag.MarcaId = marcaId;
+            var lista = _submarcas.Where(s => s.MarcaId == marcaId).ToList();
+            return View(lista);
+        }
+
+        [HttpGet]
+        public JsonResult Listar(int marcaId)
+        {
+            var lista = _submarcas.Where(s => s.MarcaId == marcaId).ToList();
+            return Json(new { success = true, data = lista });
+        }
+
+        [HttpGet]
+        public JsonResult Obtener(int id)
+        {
+            var entidad = _submarcas.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            return Json(new { success = true, data = entidad });
+        }
+
+        [HttpPost]
+        public JsonResult Guardar([FromBody] SubMarca model)
+        {
+            if (string.IsNullOrWhiteSpace(model.Nombre))
+                return Json(new { success = false, error = "El nombre es obligatorio." });
+
+            if (model.Id == 0)
+            {
+                model.Id = _nextId++;
+                _submarcas.Add(model);
+            }
+            else
+            {
+                var existente = _submarcas.FirstOrDefault(x => x.Id == model.Id);
+                if (existente == null)
+                    return Json(new { success = false, error = "No encontrado" });
+
+                existente.Nombre = model.Nombre;
+                existente.MarcaId = model.MarcaId;
+            }
+
+            return Json(new { success = true, id = model.Id });
+        }
+
+        [HttpPost]
+        public JsonResult Eliminar(int id)
+        {
+            var entidad = _submarcas.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            _submarcas.Remove(entidad);
+            return Json(new { success = true });
+        }
+    }
+}

--- a/Controllers/UnidadDeNegocioController.cs
+++ b/Controllers/UnidadDeNegocioController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using Farmacheck.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Farmacheck.Controllers
+{
+    public class UnidadDeNegocioController : Controller
+    {
+        private static readonly List<UnidadDeNegocio> _unidades = new();
+        private static int _nextId = 1;
+
+        public IActionResult Index()
+        {
+            return View(_unidades);
+        }
+
+        [HttpGet]
+        public JsonResult Listar()
+        {
+            return Json(new { success = true, data = _unidades });
+        }
+
+        [HttpGet]
+        public JsonResult Obtener(int id)
+        {
+            var entidad = _unidades.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            return Json(new { success = true, data = entidad });
+        }
+
+        [HttpPost]
+        public JsonResult Guardar([FromBody] UnidadDeNegocio model)
+        {
+            if (string.IsNullOrWhiteSpace(model.Nombre))
+                return Json(new { success = false, error = "El nombre es obligatorio." });
+
+            if (model.Id == 0)
+            {
+                model.Id = _nextId++;
+                _unidades.Add(model);
+            }
+            else
+            {
+                var existente = _unidades.FirstOrDefault(x => x.Id == model.Id);
+                if (existente == null)
+                    return Json(new { success = false, error = "No encontrado" });
+
+                existente.Nombre = model.Nombre;
+            }
+
+            return Json(new { success = true, id = model.Id });
+        }
+
+        [HttpPost]
+        public JsonResult Eliminar(int id)
+        {
+            var entidad = _unidades.FirstOrDefault(x => x.Id == id);
+            if (entidad == null)
+                return Json(new { success = false, error = "No encontrado" });
+
+            _unidades.Remove(entidad);
+            return Json(new { success = true });
+        }
+    }
+}

--- a/Models/Marca.cs
+++ b/Models/Marca.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Farmacheck.Models
+{
+    public class Marca
+    {
+        public int Id { get; set; }
+        public int UnidadDeNegocioId { get; set; }
+        public string Nombre { get; set; }
+        public string Logotipo { get; set; }
+
+        public UnidadDeNegocio UnidadDeNegocio { get; set; }
+        public ICollection<SubMarca> SubMarcas { get; set; } = new List<SubMarca>();
+    }
+}

--- a/Models/SubMarca.cs
+++ b/Models/SubMarca.cs
@@ -1,0 +1,11 @@
+namespace Farmacheck.Models
+{
+    public class SubMarca
+    {
+        public int Id { get; set; }
+        public int MarcaId { get; set; }
+        public string Nombre { get; set; }
+
+        public Marca Marca { get; set; }
+    }
+}

--- a/Models/UnidadDeNegocio.cs
+++ b/Models/UnidadDeNegocio.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Farmacheck.Models
+{
+    public class UnidadDeNegocio
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; }
+
+        public ICollection<Marca> Marcas { get; set; } = new List<Marca>();
+    }
+}

--- a/Views/Marca/Index.cshtml
+++ b/Views/Marca/Index.cshtml
@@ -1,0 +1,135 @@
+@model List<Farmacheck.Models.Marca>
+@{
+    ViewData["Title"] = "Marcas";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="text-dark">Marcas</h4>
+        <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
+            <i class="bi bi-plus-circle"></i> Nueva marca
+        </button>
+    </div>
+    <table class="table table-bordered custom-table" id="tablaDatos">
+        <thead>
+            <tr>
+                <th style="width:20%;">Id</th>
+                <th style="width:60%;">Nombre</th>
+                <th style="width:20%;" class="text-center"></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-primary_form text-white">
+                <h5 class="modal-title" id="modalTitulo">Nueva marca</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="entidadId" />
+                <div class="mb-2">
+                    <label>Nombre</label>
+                    <input type="text" class="form-control" id="nombre" placeholder="Nombre" />
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="btnGuardar" class="btn btn-primary">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        const unidadId = @ViewBag.UnidadId;
+
+        $(document).ready(function () {
+            cargar();
+            $('#tablaDatos').DataTable();
+
+            $('#btnNueva').click(function () {
+                limpiar();
+                $('#modalTitulo').text('Nueva marca');
+                $('#modalEntidad').modal('show');
+            });
+
+            $('#btnGuardar').click(function () {
+                const datos = {
+                    Id: $('#entidadId').val() || 0,
+                    Nombre: $('#nombre').val(),
+                    UnidadDeNegocioId: unidadId
+                };
+                $.ajax({
+                    url: '@Url.Action("Guardar", "Marca")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            cargar();
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
+        });
+
+        function cargar() {
+            $.get('@Url.Action("Listar", "Marca")', { unidadId }, function (r) {
+                if (r.success) {
+                    const tbody = $('#tablaDatos tbody');
+                    tbody.empty();
+                    r.data.forEach(u => {
+                        tbody.append(`<tr>
+                            <td>${u.id}</td>
+                            <td>${u.nombre}</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
+                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
+                            </td>
+                        </tr>`);
+                    });
+                }
+            });
+        }
+
+        function editar(id) {
+            $.get('@Url.Action("Obtener", "Marca")', { id }, function (r) {
+                if (r.success) {
+                    const u = r.data;
+                    $('#modalTitulo').text('Editar marca');
+                    $('#entidadId').val(u.id);
+                    $('#nombre').val(u.nombre);
+                    $('#modalEntidad').modal('show');
+                } else {
+                    showAlert(r.error || 'No se pudo cargar', 'error');
+                }
+            });
+        }
+
+        function eliminar(id) {
+            confirmAction('¿Deseas eliminar esta marca?').then(function (ok) {
+                if (!ok) return;
+                $.post('@Url.Action("Eliminar", "Marca")', { id }, function (r) {
+                    if (r.success) {
+                        cargar();
+                    } else {
+                        showAlert(r.error || 'Error al eliminar', 'error');
+                    }
+                });
+            });
+        }
+
+        function limpiar() {
+            $('#entidadId').val('');
+            $('#nombre').val('');
+        }
+    </script>
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
         
         <!-- MENÚ -->
         <div class="px-3 pt-3 w-100 flex-grow-1">
-            <a href="#" class="d-block py-2 text-white"><i class="bi bi-building me-2"></i> Unidades de negocio</a>
+            <a asp-controller="UnidadDeNegocio" asp-action="Index" class="d-block py-2 text-white"><i class="bi bi-building me-2"></i> Unidades de negocio</a>
             <a href="#" class="d-block py-2 text-white"><i class="bi bi-geo-alt me-2"></i> Ubicaciones</a>
             <a href="#" class="d-block py-2 text-white"><i class="bi bi-person-badge me-2"></i> Roles</a>
             <a href="#" class="d-block py-2 text-white"><i class="bi bi-people me-2"></i> Usuarios</a>

--- a/Views/SubMarca/Index.cshtml
+++ b/Views/SubMarca/Index.cshtml
@@ -1,0 +1,135 @@
+@model List<Farmacheck.Models.SubMarca>
+@{
+    ViewData["Title"] = "SubMarcas";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="text-dark">Submarcas</h4>
+        <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
+            <i class="bi bi-plus-circle"></i> Nueva submarca
+        </button>
+    </div>
+    <table class="table table-bordered custom-table" id="tablaDatos">
+        <thead>
+            <tr>
+                <th style="width:20%;">Id</th>
+                <th style="width:60%;">Nombre</th>
+                <th style="width:20%;" class="text-center"></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-primary_form text-white">
+                <h5 class="modal-title" id="modalTitulo">Nueva submarca</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="entidadId" />
+                <div class="mb-2">
+                    <label>Nombre</label>
+                    <input type="text" class="form-control" id="nombre" placeholder="Nombre" />
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="btnGuardar" class="btn btn-primary">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        const marcaId = @ViewBag.MarcaId;
+
+        $(document).ready(function () {
+            cargar();
+            $('#tablaDatos').DataTable();
+
+            $('#btnNueva').click(function () {
+                limpiar();
+                $('#modalTitulo').text('Nueva submarca');
+                $('#modalEntidad').modal('show');
+            });
+
+            $('#btnGuardar').click(function () {
+                const datos = {
+                    Id: $('#entidadId').val() || 0,
+                    Nombre: $('#nombre').val(),
+                    MarcaId: marcaId
+                };
+                $.ajax({
+                    url: '@Url.Action("Guardar", "SubMarca")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            cargar();
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
+        });
+
+        function cargar() {
+            $.get('@Url.Action("Listar", "SubMarca")', { marcaId }, function (r) {
+                if (r.success) {
+                    const tbody = $('#tablaDatos tbody');
+                    tbody.empty();
+                    r.data.forEach(u => {
+                        tbody.append(`<tr>
+                            <td>${u.id}</td>
+                            <td>${u.nombre}</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
+                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
+                            </td>
+                        </tr>`);
+                    });
+                }
+            });
+        }
+
+        function editar(id) {
+            $.get('@Url.Action("Obtener", "SubMarca")', { id }, function (r) {
+                if (r.success) {
+                    const u = r.data;
+                    $('#modalTitulo').text('Editar submarca');
+                    $('#entidadId').val(u.id);
+                    $('#nombre').val(u.nombre);
+                    $('#modalEntidad').modal('show');
+                } else {
+                    showAlert(r.error || 'No se pudo cargar', 'error');
+                }
+            });
+        }
+
+        function eliminar(id) {
+            confirmAction('¿Deseas eliminar esta submarca?').then(function (ok) {
+                if (!ok) return;
+                $.post('@Url.Action("Eliminar", "SubMarca")', { id }, function (r) {
+                    if (r.success) {
+                        cargar();
+                    } else {
+                        showAlert(r.error || 'Error al eliminar', 'error');
+                    }
+                });
+            });
+        }
+
+        function limpiar() {
+            $('#entidadId').val('');
+            $('#nombre').val('');
+        }
+    </script>
+}

--- a/Views/UnidadDeNegocio/Index.cshtml
+++ b/Views/UnidadDeNegocio/Index.cshtml
@@ -1,0 +1,132 @@
+@model List<Farmacheck.Models.UnidadDeNegocio>
+@{
+    ViewData["Title"] = "Unidades de negocio";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="text-dark">Unidades de negocio</h4>
+        <button id="btnNueva" class="btn" style="background-color:#00ab8e; color:white;">
+            <i class="bi bi-plus-circle"></i> Nueva unidad
+        </button>
+    </div>
+    <table class="table table-bordered custom-table" id="tablaDatos">
+        <thead>
+            <tr>
+                <th style="width:20%;">Id</th>
+                <th style="width:60%;">Nombre</th>
+                <th style="width:20%;" class="text-center"></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="modalEntidad" tabindex="-1" aria-labelledby="modalTitulo" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-primary_form text-white">
+                <h5 class="modal-title" id="modalTitulo">Nueva unidad</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="entidadId" />
+                <div class="mb-2">
+                    <label>Nombre</label>
+                    <input type="text" class="form-control" id="nombre" placeholder="Nombre" />
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="btnGuardar" class="btn btn-primary">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            cargar();
+            $('#tablaDatos').DataTable();
+
+            $('#btnNueva').click(function () {
+                limpiar();
+                $('#modalTitulo').text('Nueva unidad');
+                $('#modalEntidad').modal('show');
+            });
+
+            $('#btnGuardar').click(function () {
+                const datos = {
+                    Id: $('#entidadId').val() || 0,
+                    Nombre: $('#nombre').val()
+                };
+                $.ajax({
+                    url: '@Url.Action("Guardar", "UnidadDeNegocio")',
+                    method: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(datos),
+                    success: function (r) {
+                        if (r.success) {
+                            $('#modalEntidad').modal('hide');
+                            cargar();
+                        } else {
+                            showAlert(r.error || 'Error al guardar', 'error');
+                        }
+                    }
+                });
+            });
+        });
+
+        function cargar() {
+            $.get('@Url.Action("Listar", "UnidadDeNegocio")', function (r) {
+                if (r.success) {
+                    const tbody = $('#tablaDatos tbody');
+                    tbody.empty();
+                    r.data.forEach(u => {
+                        tbody.append(`<tr>
+                            <td>${u.id}</td>
+                            <td>${u.nombre}</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm" style="background-color:#00ab8e; color:white;" onclick="editar(${u.id})"><i class="bi bi-pencil"></i></button>
+                                <button class="btn btn-sm" style="background-color:#79b828; color:white;" onclick="eliminar(${u.id})"><i class="bi bi-trash"></i></button>
+                            </td>
+                        </tr>`);
+                    });
+                }
+            });
+        }
+
+        function editar(id) {
+            $.get('@Url.Action("Obtener", "UnidadDeNegocio")', { id }, function (r) {
+                if (r.success) {
+                    const u = r.data;
+                    $('#modalTitulo').text('Editar unidad');
+                    $('#entidadId').val(u.id);
+                    $('#nombre').val(u.nombre);
+                    $('#modalEntidad').modal('show');
+                } else {
+                    showAlert(r.error || 'No se pudo cargar', 'error');
+                }
+            });
+        }
+
+        function eliminar(id) {
+            confirmAction('¿Deseas eliminar esta unidad?').then(function (ok) {
+                if (!ok) return;
+                $.post('@Url.Action("Eliminar", "UnidadDeNegocio")', { id }, function (r) {
+                    if (r.success) {
+                        cargar();
+                    } else {
+                        showAlert(r.error || 'Error al eliminar', 'error');
+                    }
+                });
+            });
+        }
+
+        function limpiar() {
+            $('#entidadId').val('');
+            $('#nombre').val('');
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- add models for UnidadDeNegocio, Marca and SubMarca
- implement controllers with in-memory CRUD logic
- create AJAX-based views for each catalog
- link UnidadDeNegocio menu option from layout

## Testing
- `dotnet build Farmacheck.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8a2ff8088331aa4987dc179ed5b3